### PR TITLE
ClusterCurator HCP channel update test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ options.yaml
 **.log
 
 e2e-go/local/
+scripts/setup/hcp
+scripts/setup/hcp.tar.gz

--- a/e2e-go/README.md
+++ b/e2e-go/README.md
@@ -2,6 +2,8 @@
 
 Ginkgo e2e test framework for self-managed hosted control plane using MCE / ACM. Currently supports AWS only.
 
+**What is tested when you run the suite:** see [docs/E2E_TEST_COVERAGE.md](docs/E2E_TEST_COVERAGE.md) for a full list of tests, labels, and how to run subsets.
+
 1. Ensure go is installed
 2. Set env variables (if not set, will default to options.yaml)
 
@@ -54,3 +56,12 @@ Ginkgo e2e test framework for self-managed hosted control plane using MCE / ACM.
 
     where:
     `-nodes` is set to number of parallel threads to run
+
+7. to run PR 511 / ACM-26476 channel-upgrade tests (ClusterCurator HostedCluster channel update):
+
+    ```bash
+    export CURATOR_ENABLED=true
+    ginkgo -v --label-filter='channel-upgrade' pkg/test
+    ```
+
+    See `pkg/README.md` for layout and PR 511 test requirements.

--- a/e2e-go/docs/E2E_TEST_COVERAGE.md
+++ b/e2e-go/docs/E2E_TEST_COVERAGE.md
@@ -1,0 +1,217 @@
+# E2E Test Coverage
+
+This document describes **what is tested** when you run the Hypershift addon e2e suite (`e2e-go/pkg/test`) and how to run subsets by label.
+
+---
+
+## What “run all e2e tests” means
+
+- **No label filter** (e.g. `ginkgo -v pkg/test`): runs **every test** in the suite. That includes create, destroy, console/CLI, metrics, must-gather, S3 secret, and channel-upgrade tests. Order is not guaranteed; create/destroy can conflict if they share clusters.
+- **With label filter** (e.g. `ginkgo -v --label-filter='e2e' pkg/test`): runs only specs that have **at least one** of the given labels. Use this to run a subset (e.g. only “e2e” checks, or only create, or only destroy).
+
+Recommended for CI or full validation:
+
+- Run **create** and **destroy** in separate stages (as in the Jenkinsfile).
+- Run **e2e** (and optionally **metrics**) after clusters exist.
+
+---
+
+## Suite bootstrap (`hcp_suite_test.go`)
+
+- **Not a test** itself; it registers the “Hypershift E2e Suite” and runs `SynchronizedBeforeSuite` once.
+- **BeforeSuite** checks/does:
+  - Kubeconfig, dynamic/kube/route/addon clients, MCE namespace.
+  - Hypershift addon manager and addon availability.
+  - Hypershift CLI version, OIDC S3 secret (AWS), hypershift operator health.
+  - ConsoleCLIDownload for `hcp` CLI.
+  - Loads config (instance type, base domain, region, node pool replicas, release image, namespace, pull secret, AWS creds, curator enabled, FIPS enabled).
+
+Environment variables that affect the suite (see also README):
+
+- `KUBECONFIG`, `MANAGED_CLUSTER_NAME`, `HCP_CLUSTER_NAME`, `HCP_NAMESPACE`, `HCP_REGION`, `HCP_NODE_POOL_REPLICAS`, `HCP_BASE_DOMAIN_NAME`, `HCP_RELEASE_IMAGE`, `HCP_INSTANCE_TYPE`, `AWS_CREDS`, `PULL_SECRET_FILE` / `PULL_SECRET`, `JUNIT_REPORT_FILE`, options file, etc.
+
+---
+
+## Tests by file and label
+
+Each block below is one **Describe**; indented items are **It** (individual test cases). Labels on the Describe apply to all Its inside it unless overridden.
+
+---
+
+### 1. `hcp_aws_create_test.go`
+
+**Describe:** Hosted Control Plane CLI AWS Create Tests  
+**Labels:** `AWS`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Creates a FIPS AWS Hosted Cluster using STS Creds | `create` | Uses `hcp` CLI to create an AWS hosted cluster (STS, FIPS if enabled, optional `pausedUntil` when curator enabled). Waits for cluster to become available and optionally checks addon. |
+
+**When you run “all” tests:** This runs if no label filter (and will create a cluster).  
+**Run only this:** `--label-filter='create && AWS'` (or `create` if only AWS is present).
+
+---
+
+### 2. `hcp_aws_destroy_test.go`
+
+**Describe:** Hosted Control Plane CLI AWS Destroy Tests  
+**Labels:** `AWS`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Destroy all AWS hosted clusters on the hub | `destroy` | Destroys all AWS hosted clusters found on the hub (via CLI). |
+| Destroy a AWS hosted cluster on the hub | `destroy-one` | Destroys a single AWS hosted cluster (name/namespace from options/env). |
+
+**When you run “all” tests:** Both destroy tests run.  
+**Run only destroy:** `--label-filter='destroy'` or `destroy-one`.
+
+---
+
+### 3. `hcp_kubevirt_create_test.go`
+
+**Describe:** Hosted Control Plane CLI KubeVirt Create Tests  
+**Labels:** `KubeVirt`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Creates a Kubevirt Hosted Cluster | `create` | Uses `hcp` CLI to create a KubeVirt hosted cluster. |
+
+**When you run “all” tests:** This runs if no label filter.  
+**Run only this:** `--label-filter='create && KubeVirt'`.
+
+---
+
+### 4. `hcp_kubevirt_destroy_test.go`
+
+**Describe:** Hosted Control Plane CLI KubeVirt Destroy Tests  
+**Labels:** `KubeVirt`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Destroy all KubeVirt hosted clusters on the hub | `destroy` | Destroys all KubeVirt hosted clusters on the hub. |
+| Destroy a KubeVirt hosted cluster on the hub | `destroy-one` | Destroys one KubeVirt hosted cluster. |
+
+**When you run “all” tests:** Both run.  
+**Run only destroy:** `--label-filter='destroy'` (or combine with `KubeVirt`).
+
+---
+
+### 5. `hcp_common_cli_route_test.go`
+
+**Describe:** Hosted Control Plane CLI Binary Tests  
+**Labels:** `@e2e`, `CLI-Links`, `AWS`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| should no longer have the old hypershift console link reference | `e2e`, `label`, `console` | Old hypershift console link is not present. |
+| should have the correct ConsoleCLIDownload display name set for hcp | `e2e`, `label`, `console` | ConsoleCLIDownload display name for `hcp` CLI. |
+| should have the correct ConsoleCLIDownload description set for hcp | `e2e`, `label`, `console` | ConsoleCLIDownload description for `hcp` CLI. |
+| should have the correct link for Linux x86_64 | `e2e`, `label`, `consoleLinks` | Download URL for Linux x86_64. |
+| should have the correct link for Linux ARM 64 | `e2e`, `label`, `consoleLinks` | Download URL for Linux ARM64. |
+| should have the correct link for Mac x86_64 | `e2e`, `label`, `consoleLinks` | Download URL for Mac x86_64. |
+| should have the correct link for Mac ARM 64 | `e2e`, `label`, `consoleLinks` | Download URL for Mac ARM64. |
+| should have the correct link for Windows x86_64 | `e2e`, `label`, `consoleLinks` | Download URL for Windows x86_64. |
+| should have the correct link for IBM Power (PPC64) | `e2e`, `consoleLinks` | Download URL for PPC64. |
+| should have the correct link for IBM Power, little endian (PPC64LE) | `e2e`, `consoleLinks` | Download URL for PPC64LE. |
+| should have the correct link for IBM Z (S390X) | `e2e`, `consoleLinks` | Download URL for S390X. |
+
+**When you run “all” tests:** All of these run.  
+**Run only CLI/console tests:** `--label-filter='@e2e'` or `--label-filter='console'` (or `consoleLinks`).
+
+---
+
+### 6. `hcp_metrics_test.go`
+
+**Describe:** Hypershift Add-on Prometheus/Metrics Tests  
+**Labels:** `metrics`, `@e2e`, `@post-upgrade`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| RHACM4K-39628: ServiceMonitor correctly deployed for Prometheus metrics | `service_monitor` | ServiceMonitor for hypershift addon metrics in the expected namespaces (MCE/ACM). |
+| RHACM4K-39627: Retrieve/observe Prometheus metrics for hypershift add-on health | `metrics`, `sanity` | Queries Prometheus for addon health metrics. |
+| RHACM4K-39474: Retrieve/observe Prometheus metrics for hosted clusters | `metrics` | Prometheus metrics for hosted clusters. |
+| RHACM4K-39627: Retrieve/observe Prometheus metrics for capacity | `metrics`, `capacity`, `sanity` | Capacity-related Prometheus metrics. |
+
+**When you run “all” tests:** All four metrics tests run (Prometheus must be available).  
+**Run only metrics:** `--label-filter='metrics'` or `@e2e` (to include this Describe).
+
+---
+
+### 7. `hcp_must_gather_test.go`
+
+**Describe:** Hypershift Add-on Must-Gather Tests  
+**Labels:** `@must-gather`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Triggers must-gather on a particular hosted cluster | (none) | Runs the must-gather script `scripts/must-gather/run_must_gather_hcp.sh` for a hosted cluster. |
+
+**When you run “all” tests:** This runs.  
+**Run only must-gather:** `--label-filter='@must-gather'`.
+
+---
+
+### 8. `hcp_rhacm4k-21843_test.go`
+
+**Describe:** RHACM4K-21843: Hypershift Addon should detect changes in S3 secret and re-install the hypershift operator  
+**Labels:** `e2e`, `@non-ui`, `RHACM4K-21843`, `AWS`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Get, modify, and verify the s3 secret | (none) | Gets current hypershift install pod, updates the OIDC S3 secret, then verifies a new hypershift-install pod is created (addon reacts to S3 secret change). Restores secret in AfterEach. |
+
+**When you run “all” tests:** This runs.  
+**Run only this:** `--label-filter='e2e'` (or `RHACM4K-21843`).
+
+---
+
+### 9. `hcp_channel_upgrade_test.go`
+
+**Describe:** PR 511 / ACM-26476: ClusterCurator HostedCluster channel update  
+**Labels:** `e2e`, `channel-upgrade`, `PR511`, `ACM-26476`, `AWS`
+
+| Test (It) | Labels | What is tested |
+|-----------|--------|----------------|
+| Channel-only update: set spec.upgrade.channel and desiredCuration upgrade, then verify HostedCluster spec.channel and curator condition | (none) | Creates/updates ClusterCurator with `spec.upgrade.channel`, sets `desiredCuration: upgrade`, waits for `hypershift-upgrade-job` condition, and asserts HostedCluster `spec.channel` (cluster-curator-controller PR 511). |
+| Available channels: HostedCluster status.version.desired.channels can be read for validation | (none) | Reads `status.version.desired.channels` from HostedCluster (validation path used by PR 511). |
+
+**When you run “all” tests:** Both run (skipped if `CURATOR_ENABLED != true`).  
+**Run only channel-upgrade:** `--label-filter='channel-upgrade'` or `e2e` to include this Describe.
+
+---
+
+## Summary: what runs when
+
+| Command | What runs |
+|---------|-----------|
+| `ginkgo -v pkg/test` | **Everything**: suite bootstrap + all Describes above (create, destroy, CLI, metrics, must-gather, S3 secret, channel-upgrade). |
+| `ginkgo -v --label-filter='create' pkg/test` | Only create Its (AWS and/or KubeVirt depending on labels). |
+| `ginkgo -v --label-filter='destroy' pkg/test` | Only destroy Its (all AWS, all KubeVirt, destroy-one for each). |
+| `ginkgo -v --label-filter='e2e' pkg/test` | Specs that have label `e2e`: channel-upgrade, RHACM4K-21843. (Note: `@e2e` is a different label; metrics and CLI use `@e2e`.) |
+| `ginkgo -v --label-filter='@e2e' pkg/test` | Specs with `@e2e`: CLI Binary Tests, Metrics Tests. |
+| `ginkgo -v --label-filter='channel-upgrade' pkg/test` | Only PR 511 / ACM-26476 channel-upgrade tests. |
+| `ginkgo -v --label-filter='metrics' pkg/test` | Only Prometheus/metrics tests. |
+| `ginkgo -v --label-filter='@must-gather' pkg/test` | Only must-gather test. |
+| `ginkgo -v --label-filter='AWS' pkg/test` | All AWS-related specs: create, destroy, CLI, RHACM4K-21843, channel-upgrade. |
+| `ginkgo -v --label-filter='KubeVirt' pkg/test` | All KubeVirt create/destroy specs. |
+
+---
+
+## Labels reference
+
+- **Platform:** `AWS`, `KubeVirt`
+- **Lifecycle:** `create`, `destroy`, `destroy-one`
+- **E2E / feature:** `e2e`, `@e2e`, `channel-upgrade`, `PR511`, `ACM-26476`, `metrics`, `@must-gather`, `CLI-Links`, `@non-ui`, `@post-upgrade`
+- **Sub-feature:** `console`, `consoleLinks`, `service_monitor`, `sanity`, `capacity`
+
+Combining labels (Ginkgo):
+
+- `--label-filter='create && AWS'` — create and AWS
+- `--label-filter='destroy || create'` — any destroy or create (OR)
+
+---
+
+## See also
+
+- **Run instructions and env:** [README.md](../README.md)
+- **Package layout and PR 511:** [pkg/README.md](../pkg/README.md)

--- a/e2e-go/pkg/README.md
+++ b/e2e-go/pkg/README.md
@@ -1,0 +1,48 @@
+# e2e-go/pkg – Test package layout
+
+This package contains the Ginkgo e2e test suite and shared utilities for the Hypershift addon.
+
+## Layout
+
+- **`test/`** – Ginkgo test specs. Suite bootstrap is in `hcp_suite_test.go`; other `*_test.go` files are feature-specific.
+- **`utils/`** – Shared helpers (Kube/dynamic clients, ClusterCurator, HostedCluster, MCE/ACM, options).
+- **`resources/`** – YAML fixtures and templates (ClusterCurator, options template).
+
+## Running tests
+
+From `e2e-go`:
+
+```bash
+# All e2e tests
+ginkgo -v --label-filter='e2e' pkg/test
+
+# PR 511 / ACM-26476 – ClusterCurator HostedCluster channel update only
+ginkgo -v --label-filter='channel-upgrade' pkg/test
+
+# Create / destroy (see repo README for env and options)
+ginkgo -v --label-filter='create' pkg/test
+ginkgo -v --label-filter='destroy' pkg/test
+```
+
+## PR 511 (cluster-curator-controller) – Channel upgrade tests
+
+**Label:** `channel-upgrade` (and `PR511`, `ACM-26476`)
+
+Tests for [PR 511](https://github.com/open-cluster-management/cluster-curator-controller/pull/511) (ACM-26476): HostedCluster channel setting without a version upgrade.
+
+- **`hcp_channel_upgrade_test.go`**
+  - **Channel-only update:** Set `spec.upgrade.channel` and `desiredCuration: upgrade`, then assert HostedCluster `spec.channel` and ClusterCurator `hypershift-upgrade-job` condition.
+  - **Available channels:** Reads `status.version.desired.channels` (used by the controller for channel validation).
+
+**Requirements:**
+
+- `CURATOR_ENABLED=true`
+- An existing HostedCluster (e.g. `HCP_CLUSTER_NAME` or options)
+- Ansible Tower secret for upgrade hooks (`CURATOR_TOWER_SECRET` or default `acmqe-hypershift/ansible-tower-secret`)
+- Optional: `HCP_UPGRADE_CHANNEL` (default `fast-4.14`) for the channel to set
+
+**Utils added for PR 511:**
+
+- `utils.SetClusterCuratorUpgradeChannel()` – patch `spec.upgrade.channel`
+- `utils.GetHostedClusterChannel()` – read HostedCluster `spec.channel`
+- `utils.GetHostedClusterAvailableChannels()` – read `status.version.desired.channels`

--- a/e2e-go/pkg/resources/clustercurator/cluster_curator_channel_upgrade.yaml
+++ b/e2e-go/pkg/resources/clustercurator/cluster_curator_channel_upgrade.yaml
@@ -1,0 +1,11 @@
+# Minimal ClusterCurator for channel-upgrade only (PR 511 / ACM-26476).
+# No Ansible Tower / prehook / posthook; used when only spec.upgrade.channel is set.
+# desiredCuration is omitted (CRD allows only enum or null, not ""); test patches it to "upgrade" after setting channel.
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: {{ .ClusterName }}
+  namespace: {{ .ClusterNamespace }}
+spec:
+  upgrade:
+    monitorTimeout: 120

--- a/e2e-go/pkg/resources/options_template.yaml
+++ b/e2e-go/pkg/resources/options_template.yaml
@@ -29,3 +29,6 @@ options:
       awsCredName: ''
     secrets:
       pullSecret: ''
+  # ClusterCurator options (e.g. for channel-upgrade test)
+  clustercurator:
+    channel: 'fast-4.20'

--- a/e2e-go/pkg/test/hcp_aws_create_test.go
+++ b/e2e-go/pkg/test/hcp_aws_create_test.go
@@ -49,6 +49,8 @@ var _ = g.Describe("Hosted Control Plane CLI AWS Create Tests:", g.Label(TYPE_AW
 			"--instance-type", config.InstanceType,
 			"--release-image", config.ReleaseImage,
 			"--arch", config.ClusterArch,
+			"--infra-availability-policy", "SingleReplica",
+			"--control-plane-availability-policy", "SingleReplica",
 		}
 		// remove secret-creds
 		// regular aws creds for s3 bucket

--- a/e2e-go/pkg/test/hcp_channel_upgrade_test.go
+++ b/e2e-go/pkg/test/hcp_channel_upgrade_test.go
@@ -1,0 +1,93 @@
+// Package hypershift_test contains e2e tests for the Hypershift addon.
+// This file tests PR 511 (cluster-curator-controller): ACM-26476 HostedCluster channel setting.
+package hypershift_test
+
+import (
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/stolostron/hypershift-addon-e2e-tests/e2e-go/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Label for PR 511 / ACM-26476 channel upgrade tests (run with: --label-filter='channel-upgrade')
+	labelChannelUpgrade = "channel-upgrade"
+)
+
+// PR 511 (cluster-curator-controller): ACM-26476 HostedCluster channel setting.
+// Tests that ClusterCurator can update a HostedCluster's channel without a version upgrade,
+// and that the controller validates channel against status.version.desired.channels.
+var _ = ginkgo.Describe("PR 511 / ACM-26476: ClusterCurator HostedCluster channel update", ginkgo.Label("e2e", labelChannelUpgrade, "PR511", "ACM-26476", TYPE_AWS), func() {
+	var (
+		clusterName    string
+		namespace      string
+		testChannel    string
+		curatorEnabled string
+	)
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		curatorEnabled, err = utils.GetCuratorEnabled()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if curatorEnabled != "true" {
+			ginkgo.Skip("CURATOR_ENABLED is not true, skipping channel-upgrade test")
+		}
+
+		clusterName, err = utils.GetClusterName("aws")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(clusterName).NotTo(gomega.BeEmpty(), "HCP_CLUSTER_NAME or options.clusters.aws.clusterName must be set")
+
+		namespace, err = utils.GetNamespace(TYPE_AWS)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Channel from options.yaml (options.clustercurator.channel) or HCP_UPGRADE_CHANNEL env, else default
+		testChannel = utils.GetClusterCuratorChannel()
+	})
+
+	ginkgo.It("Channel-only update: set spec.upgrade.channel and desiredCuration upgrade, then verify HostedCluster spec.channel and curator condition", func() {
+		ginkgo.By("Ensuring HostedCluster exists")
+		_, err := utils.GetResource(dynamicClient, utils.HostedClustersGVR, namespace, clusterName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "HostedCluster %s/%s must exist for this test", namespace, clusterName)
+
+		ginkgo.By("Creating or updating ClusterCurator (channel-upgrade only, no Ansible Tower)")
+		err = utils.CreateOrUpdateClusterCuratorForChannelUpgrade(clientClient, clusterName, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = utils.SetClusterCuratorUpgradeChannel(dynamicClient, clusterName, namespace, testChannel)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = utils.SetDesiredCuration(dynamicClient, clusterName, namespace, "upgrade")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for ClusterCurator clustercurator-job condition to become True (upgrade completed)")
+		timeout := 15 * time.Minute
+		interval := 15 * time.Second
+		// Controller sets clustercurator-job when the curator job finishes (message e.g. "curator-job-xxx DesiredCuration: upgrade Version (;channel;;;)")
+		gomega.Eventually(func() error {
+			return utils.CheckCuratorCondition(dynamicClient, clusterName, namespace,
+				"clustercurator-job", string(metav1.ConditionTrue), "", "Job_has_finished")
+		}, timeout, interval).ShouldNot(gomega.HaveOccurred())
+
+		ginkgo.By("Verifying HostedCluster spec.channel was updated")
+		channel, err := utils.GetHostedClusterChannel(dynamicClient, clusterName, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(channel).To(gomega.Equal(testChannel),
+			"HostedCluster spec.channel should be %q, got %q", testChannel, channel)
+		fmt.Printf("HostedCluster %s channel is %s\n", clusterName, channel)
+	})
+
+	ginkgo.It("Available channels: HostedCluster status.version.desired.channels can be read for validation", func() {
+		ginkgo.By("Ensuring HostedCluster exists")
+		_, err := utils.GetResource(dynamicClient, utils.HostedClustersGVR, namespace, clusterName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "HostedCluster %s/%s must exist", namespace, clusterName)
+
+		ginkgo.By("Reading HostedCluster available channels (used by PR 511 for validation)")
+		channels, err := utils.GetHostedClusterAvailableChannels(dynamicClient, clusterName, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Channels may be empty if cluster is still provisioning or channel not set yet
+		fmt.Printf("HostedCluster %s available channels: %v\n", clusterName, channels)
+	})
+})

--- a/e2e-go/pkg/test/hcp_kubevirt_create_test.go
+++ b/e2e-go/pkg/test/hcp_kubevirt_create_test.go
@@ -40,6 +40,8 @@ var _ = g.Describe("Hosted Control Plane CLI KubeVirt Create Tests:", g.Label(TY
 		commandArgs = append(commandArgs, "--cores", cores)
 		commandArgs = append(commandArgs, "--node-pool-replicas", config.NodePoolReplicas)
 		commandArgs = append(commandArgs, "--namespace", config.Namespace)
+		commandArgs = append(commandArgs, "--infra-availability-policy", "SingleReplica")
+		commandArgs = append(commandArgs, "--control-plane-availability-policy", "SingleReplica")
 
 		// default not provide release image if empty
 		commandArgs = append(commandArgs, "--release-image", config.ReleaseImage)


### PR DESCRIPTION
# Channel-upgrade tests

The **channel-upgrade tests** (label `channel-upgrade`) validate **PR 511 / ACM-26476** in cluster-curator-controller: updating a HostedCluster’s **update channel** (e.g. `stable-4.19` → `fast-4.19`) via ClusterCurator **without** changing the OCP version.

---

## What they cover

### 1. Channel-only update (main test)

- Assumes an **existing AWS HostedCluster** (name/namespace from options or `HCP_CLUSTER_NAME` / `HCP_NAMESPACE`).
- Creates a **minimal ClusterCurator** (channel-upgrade template; no Ansible Tower).
- Sets **`spec.upgrade.channel`** to the desired channel (from `options.clustercurator.channel` or `HCP_UPGRADE_CHANNEL`, default `fast-4.14`).
- Sets **`spec.desiredCuration`** to `"upgrade"` so the controller runs the upgrade job.
- Waits for the ClusterCurator to report condition **`clustercurator-job`** with status True and reason `Job_has_finished`.
- Asserts the HostedCluster’s **`spec.channel`** equals the channel that was set (i.e. the controller applied the channel-only update).

### 2. Available channels (smoke)

- Assumes an existing HostedCluster.
- Reads **`status.version.desired.channels`** from that HostedCluster.
- Confirms the field can be read (same data the controller uses to validate the channel in PR 511).

---

## What they do not test

- **Version upgrades** (`desiredUpdate` / release image) are not tested.
- **Ansible Tower** or any hooks are not used; the tests use the minimal channel-upgrade ClusterCurator template only.

---

## Requirements

| Requirement | Description |
|-------------|-------------|
| **CURATOR_ENABLED** | Must be `true` (otherwise the whole Describe is skipped). |
| **Hub** | cluster-curator-controller and Hypershift addon installed. |
| **HostedCluster** | An existing one; cluster name and namespace in options or env. |
| **Channel** | Set via `options.clustercurator.channel` or `HCP_UPGRADE_CHANNEL`, or default `fast-4.14`. |

---

## Run

```bash
cd e2e-go
export CURATOR_ENABLED=true
ginkgo -v --label-filter='channel-upgrade' pkg/test
```

Or with the channel from options only (see `pkg/resources/options.yaml`):

```yaml
  clustercurator:
    channel: 'fast-4.19'