### PR TITLE
hosted control plane only upgrade via ClusterCurator

### DIFF
--- a/e2e-go/README.md
+++ b/e2e-go/README.md
@@ -60,8 +60,35 @@ Ginkgo e2e test framework for self-managed hosted control plane using MCE / ACM.
 7. to run PR 511 / ACM-26476 channel-upgrade tests (ClusterCurator HostedCluster channel update):
 
     ```bash
-    export CURATOR_ENABLED=true
     ginkgo -v --label-filter='channel-upgrade' pkg/test
     ```
 
     See `pkg/README.md` for layout and PR 511 test requirements.
+
+8. to run control-plane-upgrade tests (ClusterCurator HostedCluster control plane upgrade only):
+
+    **Required / optional inputs** (same pattern as channel-upgrade, plus upgrade type and desiredUpdate):
+
+    - **Options file** (`resources/options.yaml` or path passed via `--options`):
+      - `options.clustercurator.channel`: target channel for the upgrade (e.g. `fast-4.19`).
+      - `options.clustercurator.upgradeType`: `ControlPlane` (control plane only), `NodePools` (node pools only), or omit/empty for both.
+      - `options.clustercurator.desiredUpdate`: target OCP version for the upgrade (e.g. `4.19.22`); maps to ClusterCurator `spec.upgrade.desiredUpdate`.
+    - **Environment variables** (override options when set):
+      - `KUBECONFIG`: hub kubeconfig (required).
+      - `HCP_CLUSTER_NAME`: existing HostedCluster name to upgrade (or set `options.clusters.aws.clusterName`).
+      - `HCP_NAMESPACE`: namespace of the HostedCluster (default `clusters`).
+      - `HCP_UPGRADE_CHANNEL`: target channel (overrides `options.clustercurator.channel`).
+      - `HCP_UPGRADE_TYPE`: `ControlPlane`, `NodePools`, or unset for both (overrides `options.clustercurator.upgradeType`).
+      - `HCP_UPGRADE_DESIRED_UPDATE`: target OCP version (e.g. `4.19.22`) (overrides `options.clustercurator.desiredUpdate`). **Required** for control-plane upgrade—the controller panics if this is empty.
+
+    Example (control-plane-only upgrade to a specific version):
+
+    ```bash
+    export HCP_CLUSTER_NAME=my-hosted-cluster
+    export HCP_UPGRADE_CHANNEL=fast-4.19
+    export HCP_UPGRADE_TYPE=ControlPlane
+    export HCP_UPGRADE_DESIRED_UPDATE=4.19.22
+    ginkgo -v --label-filter='control-plane-upgrade' pkg/test
+    ```
+
+    Or use `options.yaml` under `options.clustercurator`: set `channel`, `upgradeType: 'ControlPlane'`, and `desiredUpdate: '4.19.22'` and omit the env vars.

--- a/e2e-go/pkg/README.md
+++ b/e2e-go/pkg/README.md
@@ -19,6 +19,9 @@ ginkgo -v --label-filter='e2e' pkg/test
 # PR 511 / ACM-26476 – ClusterCurator HostedCluster channel update only
 ginkgo -v --label-filter='channel-upgrade' pkg/test
 
+# Control-plane-only upgrade
+ginkgo -v --label-filter='control-plane-upgrade' pkg/test
+
 # Create / destroy (see repo README for env and options)
 ginkgo -v --label-filter='create' pkg/test
 ginkgo -v --label-filter='destroy' pkg/test
@@ -36,7 +39,6 @@ Tests for [PR 511](https://github.com/open-cluster-management/cluster-curator-co
 
 **Requirements:**
 
-- `CURATOR_ENABLED=true`
 - An existing HostedCluster (e.g. `HCP_CLUSTER_NAME` or options)
 - Ansible Tower secret for upgrade hooks (`CURATOR_TOWER_SECRET` or default `acmqe-hypershift/ansible-tower-secret`)
 - Optional: `HCP_UPGRADE_CHANNEL` (default `fast-4.14`) for the channel to set
@@ -46,3 +48,22 @@ Tests for [PR 511](https://github.com/open-cluster-management/cluster-curator-co
 - `utils.SetClusterCuratorUpgradeChannel()` – patch `spec.upgrade.channel`
 - `utils.GetHostedClusterChannel()` – read HostedCluster `spec.channel`
 - `utils.GetHostedClusterAvailableChannels()` – read `status.version.desired.channels`
+
+## Control-plane-only upgrade tests
+
+**Label:** `control-plane-upgrade`
+
+ClusterCurator upgrade of HostedCluster control plane only (or NodePools only), without upgrading both.
+
+**Inputs (same as channel-upgrade plus upgrade type and desiredUpdate):**
+
+- Existing HostedCluster: `HCP_CLUSTER_NAME` or `options.clusters.aws.clusterName`
+- `HCP_NAMESPACE` or default `clusters`
+- Target channel: `HCP_UPGRADE_CHANNEL` or `options.clustercurator.channel`
+- **Desired update (required):** `HCP_UPGRADE_DESIRED_UPDATE` or `options.clustercurator.desiredUpdate` — target OCP version (e.g. `4.19.22`); maps to `spec.upgrade.desiredUpdate`. The controller requires this for control-plane upgrade and will panic if it is empty.
+- **Upgrade type:** `HCP_UPGRADE_TYPE` or `options.clustercurator.upgradeType` — `ControlPlane` (control plane only), `NodePools` (node pools only), or empty for both
+
+**Utils:**
+
+- `utils.GetClusterCuratorUpgradeType()` – returns upgrade type from env or options
+- `utils.GetClusterCuratorDesiredUpdate()` – returns desired update version from env or options

--- a/e2e-go/pkg/resources/options_template.yaml
+++ b/e2e-go/pkg/resources/options_template.yaml
@@ -29,6 +29,10 @@ options:
       awsCredName: ''
     secrets:
       pullSecret: ''
-  # ClusterCurator options (e.g. for channel-upgrade test)
+  # ClusterCurator options (e.g. for channel-upgrade, control-plane-upgrade tests)
   clustercurator:
-    channel: 'fast-4.20'
+    channel: 'fast-4.19'
+    # upgradeType: 'ControlPlane' | 'NodePools' | omit/empty for both (control-plane-upgrade test)
+    upgradeType: ''
+    # desiredUpdate: target OCP version for upgrade (e.g. '4.19.22'); maps to spec.upgrade.desiredUpdate
+    desiredUpdate: ''

--- a/e2e-go/pkg/test/hcp_channel_upgrade_test.go
+++ b/e2e-go/pkg/test/hcp_channel_upgrade_test.go
@@ -22,20 +22,13 @@ const (
 // and that the controller validates channel against status.version.desired.channels.
 var _ = ginkgo.Describe("PR 511 / ACM-26476: ClusterCurator HostedCluster channel update", ginkgo.Label("e2e", labelChannelUpgrade, "PR511", "ACM-26476", TYPE_AWS), func() {
 	var (
-		clusterName    string
-		namespace      string
-		testChannel    string
-		curatorEnabled string
+		clusterName string
+		namespace   string
+		testChannel string
 	)
 
 	ginkgo.BeforeEach(func() {
 		var err error
-		curatorEnabled, err = utils.GetCuratorEnabled()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		if curatorEnabled != "true" {
-			ginkgo.Skip("CURATOR_ENABLED is not true, skipping channel-upgrade test")
-		}
-
 		clusterName, err = utils.GetClusterName("aws")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(clusterName).NotTo(gomega.BeEmpty(), "HCP_CLUSTER_NAME or options.clusters.aws.clusterName must be set")

--- a/e2e-go/pkg/test/hcp_control_plane_upgrade_test.go
+++ b/e2e-go/pkg/test/hcp_control_plane_upgrade_test.go
@@ -1,0 +1,87 @@
+// Package hypershift_test contains e2e tests for the Hypershift addon.
+// This file tests control-plane-only upgrade via ClusterCurator (spec.upgrade.desiredUpdate + upgradeType: ControlPlane).
+package hypershift_test
+
+import (
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/stolostron/hypershift-addon-e2e-tests/e2e-go/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	labelControlPlaneUpgrade = "control-plane-upgrade"
+)
+
+// Control-plane-only upgrade: ClusterCurator upgrades only the HostedCluster control plane using
+// spec.upgrade.desiredUpdate and spec.upgrade.upgradeType: ControlPlane.
+var _ = ginkgo.Describe("Control-plane-only upgrade", ginkgo.Label("e2e", labelControlPlaneUpgrade, TYPE_AWS), func() {
+	var (
+		clusterName   string
+		namespace     string
+		testChannel   string
+		desiredUpdate string
+		upgradeType   string
+	)
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		clusterName, err = utils.GetClusterName("aws")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(clusterName).NotTo(gomega.BeEmpty(), "HCP_CLUSTER_NAME or options.clusters.aws.clusterName must be set")
+
+		namespace, err = utils.GetNamespace(TYPE_AWS)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		testChannel = utils.GetClusterCuratorChannel()
+		desiredUpdate = utils.GetClusterCuratorDesiredUpdate()
+		upgradeType = utils.GetClusterCuratorUpgradeType()
+	})
+
+	ginkgo.It("Control-plane only: set spec.upgrade (channel, desiredUpdate, upgradeType ControlPlane) and desiredCuration upgrade, then verify curator condition and HostedCluster release", func() {
+		ginkgo.By("Ensuring HostedCluster exists")
+		_, err := utils.GetResource(dynamicClient, utils.HostedClustersGVR, namespace, clusterName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "HostedCluster %s/%s must exist for this test", namespace, clusterName)
+
+		if upgradeType != "ControlPlane" {
+			ginkgo.Skip("control-plane-upgrade test requires upgradeType=ControlPlane (set HCP_UPGRADE_TYPE=ControlPlane or options.clustercurator.upgradeType)")
+		}
+		if desiredUpdate == "" {
+			ginkgo.Skip("control-plane-upgrade test requires desiredUpdate (set HCP_UPGRADE_DESIRED_UPDATE or options.clustercurator.desiredUpdate). The cluster-curator-controller panics with 'Version string empty' if desiredUpdate is missing.")
+		}
+
+		ginkgo.By("Creating or updating ClusterCurator (minimal, no Ansible Tower)")
+		err = utils.CreateOrUpdateClusterCuratorForChannelUpgrade(clientClient, clusterName, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Setting spec.upgrade.channel")
+		err = utils.SetClusterCuratorUpgradeChannel(dynamicClient, clusterName, namespace, testChannel)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Setting spec.upgrade.desiredUpdate and spec.upgrade.upgradeType")
+		err = utils.SetClusterCuratorUpgradeDesiredUpdateAndType(dynamicClient, clusterName, namespace, desiredUpdate, upgradeType)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Setting desiredCuration to upgrade")
+		err = utils.SetDesiredCuration(dynamicClient, clusterName, namespace, "upgrade")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for ClusterCurator clustercurator-job condition to become True (upgrade completed)")
+		timeout := 20 * time.Minute
+		interval := 15 * time.Second
+		gomega.Eventually(func() error {
+			return utils.CheckCuratorCondition(dynamicClient, clusterName, namespace,
+				"clustercurator-job", string(metav1.ConditionTrue), "", "Job_has_finished")
+		}, timeout, interval).ShouldNot(gomega.HaveOccurred())
+
+		ginkgo.By("Verifying HostedCluster spec.release reflects desired version")
+		release, err := utils.GetHostedClusterSpecRelease(dynamicClient, clusterName, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(release).To(gomega.ContainSubstring(desiredUpdate),
+			"HostedCluster spec.release should contain version %q, got %q", desiredUpdate, release)
+		fmt.Printf("HostedCluster %s release image is %s\n", clusterName, release)
+	})
+})

--- a/e2e-go/pkg/utils/options.go
+++ b/e2e-go/pkg/utils/options.go
@@ -42,9 +42,11 @@ type TestOptionsT struct {
 	ClusterCurator  ClusterCuratorOpts  `json:"clustercurator,omitempty"`
 }
 
-// ClusterCuratorOpts holds options for ClusterCurator tests (e.g. channel-upgrade).
+// ClusterCuratorOpts holds options for ClusterCurator tests (e.g. channel-upgrade, control-plane-upgrade).
 type ClusterCuratorOpts struct {
-	Channel string `json:"channel,omitempty"`
+	Channel       string `json:"channel,omitempty"`
+	UpgradeType   string `json:"upgradeType,omitempty"`   // ControlPlane, NodePools, or empty for both (control-plane-upgrade test)
+	DesiredUpdate string `json:"desiredUpdate,omitempty"` // Target OCP version for upgrade (e.g. 4.19.22); maps to spec.upgrade.desiredUpdate
 }
 
 // Hub ...
@@ -380,6 +382,26 @@ func GetClusterCuratorChannel() string {
 		return v
 	}
 	return "fast-4.14"
+}
+
+// GetClusterCuratorUpgradeType returns the upgrade type for ClusterCurator (control-plane-upgrade test).
+// Values: "ControlPlane" (control plane only), "NodePools" (node pools only), or "" (upgrade both).
+// Priority: HCP_UPGRADE_TYPE env, then options.clustercurator.upgradeType, else "".
+func GetClusterCuratorUpgradeType() string {
+	if v := os.Getenv("HCP_UPGRADE_TYPE"); v != "" {
+		return v
+	}
+	return TestOptions.Options.ClusterCurator.UpgradeType
+}
+
+// GetClusterCuratorDesiredUpdate returns the desired update version for ClusterCurator upgrade (control-plane-upgrade test).
+// Value is the target OCP version string (e.g. "4.19.22"); controller uses it to set spec.release on HostedCluster/NodePools.
+// Priority: HCP_UPGRADE_DESIRED_UPDATE env, then options.clustercurator.desiredUpdate, else "".
+func GetClusterCuratorDesiredUpdate() string {
+	if v := os.Getenv("HCP_UPGRADE_DESIRED_UPDATE"); v != "" {
+		return v
+	}
+	return TestOptions.Options.ClusterCurator.DesiredUpdate
 }
 
 // GetFIPSEnabled returns if we want to enable FIPS in cluster creation


### PR DESCRIPTION
# Add control-plane-only upgrade e2e test

## Summary

Adds an automated e2e test for ClusterCurator **control-plane-only** HostedCluster upgrades. Testers pass target channel, desired OCP version (`desiredUpdate`), and upgrade type via options file or environment variables. The test creates/updates a ClusterCurator with `spec.upgrade.channel`, `spec.upgrade.desiredUpdate`, and `spec.upgrade.upgradeType: ControlPlane`, triggers upgrade, and asserts the HostedCluster release image reflects the desired version.

Also removes the `CURATOR_ENABLED` gate from both channel-upgrade and control-plane-upgrade tests so they run without that env var.

## Changes

### Test input plumbing

- **Options** (`e2e-go/pkg/utils/options.go`, `e2e-go/pkg/resources/options_template.yaml`, `options.yaml`):
  - `ClusterCuratorOpts`: added `UpgradeType` and `DesiredUpdate`.
  - `GetClusterCuratorUpgradeType()`: returns `HCP_UPGRADE_TYPE` or `options.clustercurator.upgradeType` (e.g. `ControlPlane`, `NodePools`, or empty for both).
  - `GetClusterCuratorDesiredUpdate()`: returns `HCP_UPGRADE_DESIRED_UPDATE` or `options.clustercurator.desiredUpdate` (target OCP version string).

### ClusterCurator / HostedCluster helpers

- **`e2e-go/pkg/utils/clustercurator.go`**:
  - `SetClusterCuratorUpgradeDesiredUpdateAndType()`: merge-patches `spec.upgrade.desiredUpdate` and/or `spec.upgrade.upgradeType` on the ClusterCurator.
- **`e2e-go/pkg/utils/hostedcluster.go`**:
  - `GetHostedClusterSpecRelease()`: returns HostedCluster `spec.release` image string for post-upgrade assertion.

### New test

- **`e2e-go/pkg/test/hcp_control_plane_upgrade_test.go`**:
  - Describe: **Control-plane-only upgrade** (labels: `e2e`, `control-plane-upgrade`, `AWS`).
  - Single `It`: sets channel, desiredUpdate, upgradeType=ControlPlane, desiredCuration=upgrade; waits for `clustercurator-job` condition; asserts HostedCluster `spec.release` contains the desired version.
  - Skips unless `upgradeType=ControlPlane` and `desiredUpdate` is set (documents that the controller panics if desiredUpdate is empty).

### CURATOR_ENABLED removal

- **`hcp_channel_upgrade_test.go`** and **`hcp_control_plane_upgrade_test.go`**: removed `GetCuratorEnabled()` check and skip; both tests run without requiring `CURATOR_ENABLED=true`.
- Docs updated to stop listing `CURATOR_ENABLED` as required for these tests.

### Documentation

- **`e2e-go/README.md`**: step 8 for control-plane-upgrade (inputs, env vars, example); removed `CURATOR_ENABLED` from examples and required list.
- **`e2e-go/docs/E2E_TEST_COVERAGE.md`**: section 10 for control-plane-upgrade (inputs table, labels, command); removed CURATOR_ENABLED from channel-upgrade and control-plane-upgrade descriptions.
- **`e2e-go/pkg/README.md`**: control-plane-upgrade section (label, inputs, utils); noted desiredUpdate is required; removed CURATOR_ENABLED from requirements.

## How to run

```bash
# Control-plane-only upgrade (set target version and type)
export HCP_CLUSTER_NAME=my-hosted-cluster
export HCP_UPGRADE_CHANNEL=fast-4.19
export HCP_UPGRADE_TYPE=ControlPlane
export HCP_UPGRADE_DESIRED_UPDATE=4.19.22
ginkgo -v --label-filter='control-plane-upgrade' pkg/test
```

Or set `options.clustercurator.channel`, `upgradeType: 'ControlPlane'`, and `desiredUpdate: '4.19.22'` in `resources/options.yaml` and run the same `ginkgo` command from `e2e-go`.
